### PR TITLE
Upgrade gson to version 2.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.1</version>
         </dependency>
         <dependency>
             <groupId>net.sf.saxon</groupId>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades gson to 2.9.1 to fix vulnerabilities in current version