### PR TITLE
Upgrade commons-compress to version 1.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,12 @@
         </dependency>
 
 
-    </dependencies>
+      <dependency>
+         <groupId>org.apache.commons</groupId>
+         <artifactId>commons-compress</artifactId>
+         <version>1.24.0</version>
+      </dependency>
+   </dependencies>
 
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades commons-compress to 1.24.0 to fix vulnerabilities in current version